### PR TITLE
Install git, not git-core, on 18.04

### DIFF
--- a/.kitchen.dokken.yml
+++ b/.kitchen.dokken.yml
@@ -35,6 +35,14 @@ platforms:
        - RUN /usr/bin/apt-get -y update
        - RUN /usr/bin/apt-get install -y sudo
 
+- name: ubuntu-18.04
+  driver:
+    image: dokken/ubuntu-18.04
+    pid_one_command: /bin/systemd
+    intermediate_instructions:
+       - RUN /usr/bin/apt-get -y update
+       - RUN /usr/bin/apt-get install -y sudo
+
 suites:
   - name: test
     run_list:

--- a/libraries/chef_asdf_package_helpers.rb
+++ b/libraries/chef_asdf_package_helpers.rb
@@ -21,7 +21,16 @@ class Chef
   module Asdf
     module PackageHelpers
       def install_asdf_deps
-        apt_package %w(automake autoconf build-essential git-core grep libreadline-dev libncurses-dev libssl-dev libyaml-dev libxslt-dev libffi-dev libtool unixodbc-dev unzip)
+        packages = %w(automake autoconf build-essential grep libreadline-dev libncurses-dev libssl-dev libyaml-dev libxslt-dev libffi-dev libtool unixodbc-dev unzip)
+
+        case node['platform_version']
+        when '18.04'
+          packages << 'git'
+        else
+          packages << 'git-core'
+        end
+
+        apt_package packages
       end
 
       def install_package_deps(package)


### PR DESCRIPTION
### Description

On my Ubuntu 18.04 laptop, I had an error during the package install indicating that `git-core` was a virtual package.

### Contribution Check List

- [x] All tests pass.
- [x] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable

(Only added a kitchen config for 18.04, hope that that's enough)