### PR TITLE
Correct asdf_package action typo.

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ This resource has the following actions:
 
 - `:install` Default. Install package.
 - `:global` Set package global.
-- `:uninsstall` Uninstall package.
+- `:uninstall` Uninstall package.
 
 ### Properties
 


### PR DESCRIPTION
### Description

This corrects an typo in the README for the `asdf_package` action.
